### PR TITLE
Fixed bug caused by not passing scope in wrapNodeFire()

### DIFF
--- a/nodefire.js
+++ b/nodefire.js
@@ -696,7 +696,7 @@ function delegateNodeFire(method) {
 function wrapNodeFire(method) {
   NodeFire.prototype[method] = function() {
     return new NodeFire(
-      this.$firebase[method].apply(this.$firebase, arguments), undefined, this.$host);
+      this.$firebase[method].apply(this.$firebase, arguments), this.$scope, this.$host);
   };
 }
 


### PR DESCRIPTION
The example in the `README` actually doesn't work out of the box because the scope is not passed along when `root()` is called in `theUser: stuff.root().child('users/{baz.qux}').get()`. The fix is to pass along `this.$scope` within `wrapNodeFire()` so each method has access to that same scope.