### PR TITLE
Properly clone scope when created new NodeFire instance in wrapNodeFire()

### DIFF
--- a/nodefire.js
+++ b/nodefire.js
@@ -696,7 +696,7 @@ function delegateNodeFire(method) {
 function wrapNodeFire(method) {
   NodeFire.prototype[method] = function() {
     return new NodeFire(
-      this.$firebase[method].apply(this.$firebase, arguments), this.$scope, this.$host);
+      this.$firebase[method].apply(this.$firebase, arguments), _.clone(this.$scope), this.$host);
   };
 }
 


### PR DESCRIPTION
I'm not quite sure how I lost that `_.clone()` in my initial PR with this fix, but this is more correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pkaminski/nodefire/4)
<!-- Reviewable:end -->
