### PR TITLE
Add database property and make properties work with Query instances

### DIFF
--- a/nodefire.js
+++ b/nodefire.js
@@ -116,11 +116,19 @@ class NodeFire {
   }
 
   /**
+   * Returns the database instance corresponding to this reference.
+   * @return {admin.database.Database} The database instance corresponding to this reference.
+   */
+  get database() {
+    return this.$ref.ref.database;
+  }
+
+  /**
    * Returns the last part of this reference's path. The key of a root reference is `null`.
    * @return {string|null} The last part this reference's path.
    */
   get key() {
-    return this.$ref.key;
+    return this.$ref.ref.key;
   }
 
   /**
@@ -128,7 +136,7 @@ class NodeFire {
    * @return {string} The path component of the Firebase URL wrapped by this NodeFire object.
    */
   get path() {
-    return decodeURIComponent(this.$ref.toString()).slice(this.$ref.root.toString().length - 1);
+    return decodeURIComponent(this.$ref.toString()).slice(this.$ref.ref.root.toString().length - 1);
   }
 
   /**
@@ -148,10 +156,10 @@ class NodeFire {
    * @return {NodeFire} The root reference of the database.
    */
   get root() {
-    if (this.$ref.isEqual(this.$ref.root)) {
+    if (this.$ref.isEqual(this.$ref.ref.root)) {
       return this;
     } else {
-      return new NodeFire(this.$ref.root, this.$scope, this.$host);
+      return new NodeFire(this.$ref.ref.root, this.$scope, this.$host);
     }
   }
 
@@ -161,10 +169,10 @@ class NodeFire {
    * @return {NodeFire|null} The parent location of this reference.
    */
   get parent() {
-    if (this.$ref.parent === null) {
+    if (this.$ref.ref.parent === null) {
       return null;
     } else {
-      return new NodeFire(this.$ref.parent, this.$scope, this.$host);
+      return new NodeFire(this.$ref.ref.parent, this.$scope, this.$host);
     }
   }
 

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -7,11 +7,15 @@ const NodeFire = require('../nodefire.js');
 
 console.log(`[INFO] Running tests...`)
 
-const rootRef = new NodeFire(admin.database().ref());
-const rootQueryRef = rootRef.startAt('a').endAt('b').orderByKey().limitToFirst(10);
+const db = admin.database();
+const rootRef = new NodeFire(db.ref());
 const fooRef = rootRef.child('foo');
 const barRef = fooRef.child('bar');
+const barQueryRef = barRef.startAt('a').endAt('b').orderByKey().limitToFirst(10);
 const randomRef = rootRef.push();
+
+assert(barRef.database === db, `barRef.database should equal the original database instance`);
+assert(barQueryRef.database === db, `barQueryRef.database should equal the original database instance`);
 
 assert(rootRef.key === null, `rootRef.key should be null`);
 assert(rootRef.parent === null, `rootRef.parent should be null`);
@@ -21,16 +25,27 @@ assert(fooRef.parent.key === null, `fooRef.key.parent.key should be null`);
 assert(rootRef.isEqual(fooRef.parent), `rootRef.isEqual(fooRef.parent) should be true`);
 
 assert(barRef.key === 'bar', `barRef.key should be 'bar'`);
+assert(barQueryRef.key === 'bar', `barQueryRef.key should be 'bar'`);
 assert(barRef.parent.key === 'foo', `barRef.parent.key should be 'foo'`);
+assert(barQueryRef.parent.key === 'foo', `barQueryRef.parent.key should be 'foo'`);
 assert(!rootRef.isEqual(barRef.parent), `rootRef.isEqual(barRef.parent) should be false`);
+assert(!rootRef.isEqual(barQueryRef.parent), `rootRef.isEqual(barQueryRef.parent) should be false`);
 assert(fooRef.isEqual(barRef.parent), `fooRef.isEqual(barRef.parent) should be true`);
+assert(fooRef.isEqual(barQueryRef.parent), `fooRef.isEqual(barQueryRef.parent) should be true`);
 assert(rootRef.isEqual(barRef.parent.parent), `rootRef.isEqual(barRef.parent.parent) should be true`);
+assert(rootRef.isEqual(barQueryRef.parent.parent), `rootRef.isEqual(barQueryRef.parent.parent) should be true`);
 
 assert(rootRef.isEqual(rootRef.ref), `rootRef.isEqual(rootRef.ref) should be true`);
 assert(rootRef.isEqual(rootRef.ref.ref), `rootRef.isEqual(rootRef.ref.ref) should be true`);
-assert(!rootRef.isEqual(rootQueryRef), `rootRef.isEqual(rootQueryRef) should be false`);
-assert(rootRef.isEqual(rootQueryRef.ref), `rootRef.isEqual(rootQueryRef.ref) should be true`);
-assert(!rootQueryRef.isEqual(rootQueryRef.ref), `rootQueryRef.isEqual(rootQueryRef.ref) should be false`);
+assert(!barRef.isEqual(barQueryRef), `barRef.isEqual(barQueryRef) should be false`);
+assert(barRef.isEqual(barQueryRef.ref), `barRef.isEqual(barQueryRef.ref) should be true`);
+assert(!barQueryRef.isEqual(barQueryRef.ref), `barQueryRef.isEqual(barQueryRef.ref) should be false`);
+assert(!barQueryRef.isEqual(barQueryRef.root), `barQueryRef.isEqual(barQueryRef.root) should be false`);
+
+assert(rootRef.path === '/', `rootRef.path should be "/"`);
+assert(barRef.path === '/foo/bar', `barRef.path should be "/foo/bar"`);
+assert(barQueryRef.path === '/foo/bar', `barQueryRef.path should be "/foo/bar"`);
+
 
 let accessToken;
 


### PR DESCRIPTION
In the Firebase SDK, the properties `key`, `parent`, and `root` exist on [`admin.database.Reference`](https://firebase.google.com/docs/reference/admin/node/admin.database.Reference), but not on [`admin.database.Query`](https://firebase.google.com/docs/reference/admin/node/admin.database.Query). These properties will all return `undefined` if called from a `Query` instance. This is already annoying enough and I can tell you from experience leads to some hard-to-track down bugs. It's even worse in NodeFire since these methods will actually throw obscure errors given that getters were defined for those properties and I wasn't handling this situation. Instead of just returning `undefined`, I decided to make these properties work with both `Reference` and `Query` instances. If you prefer we remain 100% compatible with the Firebase SDK, I can update the getters to return `undefined` if they are provided with a `Query` instance.

In addition, I added the undocumented (not because it isn't supposed to be used, but because it is actually just undocumented - I sent them a bug report about it) `database` property, which will come in handy for us later when we need to grab the `App` instance off of a `Reference`.

I also added some tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pkaminski/nodefire/8)
<!-- Reviewable:end -->
