### PR TITLE
Replace host keys with app name. Memoize path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,9 @@ class NodeFire;
  * Creates a new NodeFire wrapper around a raw Firebase Admin reference.
  *
  * @param {admin.database.Query} refOrUrl A fully authenticated Firebase Admin reference or query.
- * @param {Object} options Optional dictionary containing options.
-  * @param {Object} options.scope Optional dictionary that will be used for interpolating paths.
-  * @param {string} options.host For internal use only, do not pass.
+ * @param {Object} scope Optional dictionary that will be used for interpolating paths.
  */
-constructor(ref, options)
+constructor(ref, scope)
 
 /**
  * Flag that indicates whether to log transactions and the number of tries needed.
@@ -115,14 +113,14 @@ static interceptOperations(callback)
 static setCacheSize(max)
 
 /**
- * Sets the maximum number of pinned values to retain in the cache when a host gets disconnected.
+ * Sets the maximum number of pinned values to retain in the cache when an app gets disconnected.
  * By default all values are retained, but if your cache size is high they'll all need to be double-
  * checked against the Firebase server when the connection comes back.  It may thus be more
  * economical to drop the least used ones when disconnected.
- * @param {number} max The maximum number of values from a disconnected host to keep pinned in the
+ * @param {number} max The maximum number of values from a disconnected app to keep pinned in the
  *        cache.
  */
-static setCacheSizeForDisconnectedHost(max)
+static setCacheSizeForDisconnectedApp(max)
 
 /**
  * Gets the current number of values pinned in the cache.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodefire",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A promise-centric Firebase library for NodeJS",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Welp, v1 lasted almost 2 days.  I also got rid of the `options` parameter in the constructor since I don't expect needing to pass anything more than `scope` in the future, and this avoids the overhead of creating short-lived options object whenever we call `child` or a number of other common methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pkaminski/nodefire/18)
<!-- Reviewable:end -->
