### PR TITLE
Fix NodeFire root and parent navigation types

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ type WritePatterns = [
 const db = new NodeFire<FirebaseData, WritePatterns>(admin.database().ref());
 ```
 
+Typed navigation retains the database schema: `child()` specializes the value and write types,
+`parent` restores the immediate parent types, and `root` restores the database-root types.  A
+widened runtime child path has an `unknown` value and parent type, while its `root` remains typed.
+
 ## API
 
 This is reproduced from the source code, which is authoritative.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodefire",
-  "version": "6.2.0",
+  "version": "7.0.0",
   "description": "A promise-centric Firebase library for NodeJS",
   "main": "built/index.js",
   "types": "built/index.d.ts",
@@ -15,8 +15,8 @@
     "update": "yarn up -R '*' && yarn dedupe --strategy highest",
     "latest": "yarn npm-check-updates -i -m --packageManager yarn --install never && yarn install",
     "upgrade": "reviewable-upgrade",
-    "lint": "eslint src/*.ts",
-    "check-types": "tsc --noEmit --skipLibCheck",
+    "lint": "eslint src/*.ts tests/*.ts",
+    "check-types": "tsc --noEmit --skipLibCheck && tsc --project tests/tsconfig.json --skipLibCheck",
     "build": "tsc",
     "prepublish": "tsc"
   },
@@ -46,6 +46,6 @@
     "eslint": "^10.7.0",
     "npm-check-updates": "^22.2.9",
     "reviewable-configs": "Reviewable/reviewable-configs#master",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.0"
   }
 }

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -7,8 +7,20 @@ import {LRUCache} from 'lru-cache';
 import firebaseChildrenKeys from 'firebase-childrenkeys';
 import {Simulator} from 'firefight';
 
+// Give conditional types a single inference site for NodeFire's public generic parameters.
+declare const NODE_FIRE_TYPES: unique symbol;
+interface NodeFireTypeCarrier {
+  readonly [NODE_FIRE_TYPES]: readonly [
+    unknown,
+    readonly WriteSpecialRule<any, any, any>[],
+    unknown
+  ];
+}
+
+type AnyNodeFire = NodeFire<any, any, any>;
+
 export type InterceptOperationsCallback = (
-  op: {ref: NodeFire, method: string, args: any[]},
+  op: {ref: AnyNodeFire, method: string, args: any[]},
   options: any
 ) => Promise<void> | void;
 
@@ -23,7 +35,7 @@ export type NormalizedValue<T> =
   T;
 export type ReadValue<T> = Exclude<NormalizedValue<T>, undefined>;
 
-let cache: LRUCache<string, NodeFire> | null;
+let cache: LRUCache<string, AnyNodeFire> | null;
 let cacheHits = 0, cacheMisses = 0;
 const serverTimeOffsets = {}, serverDisconnects = {}, simulators = {};
 const operationInterceptors: InterceptOperationsCallback[] = [];
@@ -61,9 +73,12 @@ declare module '@firebase/database-types' {
  */
 export default class NodeFire<
   Root = any,
-  WriteSpecialRules extends readonly WriteSpecialRule<any, any, any>[] = [],
-  WriteRoot = WriteShape<Root, WriteSpecialRules>
+  WriteSpecialRules extends readonly WriteSpecialRule<any, any, any>[] =
+  IsAny<Root> extends true ? any : [],
+  WriteRoot = IsAny<Root> extends true ? any : WriteShape<Root, WriteSpecialRules>
 > {
+  declare readonly [NODE_FIRE_TYPES]: readonly [Root, WriteSpecialRules, WriteRoot];
+
   /**
    * Flag that indicates whether to log transactions and the number of tries needed.
    */
@@ -136,18 +151,26 @@ export default class NodeFire<
    * Returns a NodeFire reference at the same location as this query or reference.
    * @return A NodeFire reference at the same location as this query or reference.
    */
-  get ref(): NodeFire<Root, WriteSpecialRules, WriteRoot> {
-    if (this.$ref.isEqual(this.$ref.ref)) return this;
-    return new NodeFire(this.$ref.ref, this.$scope);
+  get ref(): NoInfer<SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>> {
+    if (this.$ref.isEqual(this.$ref.ref)) {
+      return this as unknown as SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>;
+    }
+    return new NodeFire(this.$ref.ref, this.$scope) as SameNodeFire<
+      this, Root, WriteSpecialRules, WriteRoot
+    >;
   }
 
   /**
    * Returns a NodeFire reference to the root of the database.
    * @return {NodeFire} The root reference of the database.
    */
-  get root(): NodeFire<Root, WriteSpecialRules, WriteRoot> {
-    if (this.$ref.isEqual(this.$ref.ref.root)) return this;
-    return new NodeFire(this.$ref.ref.root, this.$scope);
+  get root(): NoInfer<RootNodeFire<this, Root, WriteSpecialRules, WriteRoot>> {
+    if (this.$ref.isEqual(this.$ref.ref.root)) {
+      return this as unknown as RootNodeFire<this, Root, WriteSpecialRules, WriteRoot>;
+    }
+    return new NodeFire(this.$ref.ref.root, this.$scope) as RootNodeFire<
+      this, Root, WriteSpecialRules, WriteRoot
+    >;
   }
 
   /**
@@ -155,9 +178,12 @@ export default class NodeFire<
    * reference is `null`.
    * @return {NodeFire|null} The parent location of this reference.
    */
-  get parent(): NodeFire<Root, WriteSpecialRules, WriteRoot> | null {
+  get parent(): NoInfer<ParentNodeFire<this, Root, WriteSpecialRules, WriteRoot>> | null {
     if (this.$ref.ref.parent === null) return null;
-    return new NodeFire(this.$ref.ref.parent, this.$scope);
+    // The type-only Parents chain mirrors the reference path built by child() and push().
+    return new NodeFire(this.$ref.ref.parent, this.$scope) as ParentNodeFire<
+      this, Root, WriteSpecialRules, WriteRoot
+    >;
   }
 
   /**
@@ -218,7 +244,7 @@ export default class NodeFire<
    * @param {Nodefire} otherRef Another NodeFire instance against which to compare.
    * @return {boolean}
    */
-  isEqual(otherRef: NodeFire): boolean {
+  isEqual(otherRef: AnyNodeFire): boolean {
     return this.$ref.isEqual(otherRef.$ref);
   }
 
@@ -236,8 +262,10 @@ export default class NodeFire<
    *     precedence over) the one carried by this NodeFire object.
    * @return A new NodeFire object with the same reference and new scope.
    */
-  scope(scope: Scope): NodeFire<Root, WriteSpecialRules, WriteRoot> {
-    return new NodeFire(this.$ref, _.assign(_.clone(this.$scope), scope));
+  scope(scope: Scope): NoInfer<SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>> {
+    return new NodeFire(
+      this.$ref, _.assign(_.clone(this.$scope), scope)
+    ) as SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>;
   }
 
   /**
@@ -250,12 +278,12 @@ export default class NodeFire<
    * @return {NodeFire} A new NodeFire object on the child reference, and with the augmented scope.
    */
   child<P extends string>(path: P & ReadPathInput<Root, P>, scope?: Scope):
-    NodeFire<ReadResultFor<Root, P>, WriteSpecialRules, ResultFor<WriteRoot, P>>;
+    NoInfer<ChildNodeFireOf<this, P>>;
 
   child<TypePaths extends string>(path: string, scope?: Scope):
-    NodeFire<ReadResultFor<Root, TypePaths>, WriteSpecialRules, ResultFor<WriteRoot, TypePaths>>;
+    NoInfer<ChildNodeFireOf<this, TypePaths>>;
 
-  child(path: string, scope: Scope = {}): NodeFire {
+  child(path: string, scope: Scope = {}): AnyNodeFire {
     const child = this.scope(scope);
     return new NodeFire(this.$ref.ref.child(child.interpolate(path)), child.$scope);
   }
@@ -268,11 +296,9 @@ export default class NodeFire<
    *     interpolated and must already be escaped, if necessary.
    * @returns {NodeFire} A new NodeFire object on the child reference.
    */
-  childRaw<P extends string>(
-    path: P & ReadPathInput<Root, P>
-  ): NodeFire<ReadResultFor<Root, P>, WriteSpecialRules, ResultFor<WriteRoot, P>>;
+  childRaw<P extends string>(path: P & ReadPathInput<Root, P>): NoInfer<ChildNodeFireOf<this, P>>;
 
-  childRaw(path: string): NodeFire {
+  childRaw(path: string): AnyNodeFire {
     return new NodeFire(this.$ref.ref.child(path as string), _.clone(this.$scope));
   }
 
@@ -378,13 +404,21 @@ export default class NodeFire<
    * @return A promise that is resolved to a new NodeFire object that refers to the newly
    *     pushed value (with the same scope as this object), or rejected with an error.
    */
-  push(value: PushValue<WriteRoot> | null, options?: { timeout?: number }): Promise<NodeFire> {
+  push(
+    value: PushValue<WriteRoot> | null, options?: { timeout?: number }
+  ): Promise<NoInfer<PushedNodeFire<this, Root, WriteSpecialRules, WriteRoot>>> {
     if (_.isNil(value)) {
-      return Promise.resolve(new NodeFire(this.$ref.ref.push(), this.$scope));
+      return Promise.resolve(
+        new NodeFire(this.$ref.ref.push(), this.$scope) as unknown as PushedNodeFire<
+          this, Root, WriteSpecialRules, WriteRoot
+        >
+      );
     }
     return invoke({ref: this, method: 'push', args: [value]}, options, (opts: any) => {
       const ref = this.$ref.ref.push(value);
-      return ref.then(() => new NodeFire(ref, this.$scope));
+      return ref.then(() => new NodeFire(ref, this.$scope) as unknown as PushedNodeFire<
+        this, Root, WriteSpecialRules, WriteRoot
+      >);
     });
   }
 
@@ -725,36 +759,64 @@ export default class NodeFire<
     });
   }
 
-  orderByChild(path: string): NodeFire {
-    return new NodeFire(this.$ref.orderByChild(path), this.$scope);
+  orderByChild(
+    path: string
+  ): NoInfer<SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>> {
+    return new NodeFire(this.$ref.orderByChild(path), this.$scope) as SameNodeFire<
+      this, Root, WriteSpecialRules, WriteRoot
+    >;
   }
 
-  equalTo(value: PrimitiveValue): NodeFire {
-    return new NodeFire(this.$ref.equalTo(value), this.$scope);
+  equalTo(
+    value: PrimitiveValue
+  ): NoInfer<SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>> {
+    return new NodeFire(this.$ref.equalTo(value), this.$scope) as SameNodeFire<
+      this, Root, WriteSpecialRules, WriteRoot
+    >;
   }
 
-  limitToFirst(limit: number): NodeFire {
-    return new NodeFire(this.$ref.limitToFirst(limit), this.$scope);
+  limitToFirst(
+    limit: number
+  ): NoInfer<SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>> {
+    return new NodeFire(this.$ref.limitToFirst(limit), this.$scope) as SameNodeFire<
+      this, Root, WriteSpecialRules, WriteRoot
+    >;
   }
 
-  limitToLast(limit: number): NodeFire {
-    return new NodeFire(this.$ref.limitToLast(limit), this.$scope);
+  limitToLast(
+    limit: number
+  ): NoInfer<SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>> {
+    return new NodeFire(this.$ref.limitToLast(limit), this.$scope) as SameNodeFire<
+      this, Root, WriteSpecialRules, WriteRoot
+    >;
   }
 
-  startAt(value: PrimitiveValue, key?: string): NodeFire {
-    return new NodeFire(this.$ref.startAt(value, key), this.$scope);
+  startAt(
+    value: PrimitiveValue, key?: string
+  ): NoInfer<SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>> {
+    return new NodeFire(this.$ref.startAt(value, key), this.$scope) as SameNodeFire<
+      this, Root, WriteSpecialRules, WriteRoot
+    >;
   }
 
-  endAt(value: PrimitiveValue, key?: string): NodeFire {
-    return new NodeFire(this.$ref.endAt(value, key), this.$scope);
+  endAt(
+    value: PrimitiveValue, key?: string
+  ): NoInfer<SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>> {
+    return new NodeFire(this.$ref.endAt(value, key), this.$scope) as SameNodeFire<
+      this, Root, WriteSpecialRules, WriteRoot
+    >;
   }
 
-  orderByKey(): NodeFire {
-    return new NodeFire(this.$ref.orderByKey(), this.$scope);
+  orderByKey(): NoInfer<SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>> {
+    return new NodeFire(this.$ref.orderByKey(), this.$scope) as SameNodeFire<
+      this, Root, WriteSpecialRules, WriteRoot
+    >;
   }
 
-  orderByValue(): NodeFire {
-    return new NodeFire(this.$ref.orderByValue(), this.$scope);
+  orderByValue(): NoInfer<SameNodeFire<this, Root, WriteSpecialRules, WriteRoot>> {
+    return new NodeFire(this.$ref.orderByValue(), this.$scope) as SameNodeFire<
+      this, Root, WriteSpecialRules, WriteRoot
+    >;
   }
 }
 
@@ -766,8 +828,8 @@ export default class NodeFire<
  */
 export class Snapshot<Root> {
   $snap: DataSnapshot;
-  $nodeFire: NodeFire;
-  constructor(snap: DataSnapshot, nodeFire: NodeFire) {
+  $nodeFire: AnyNodeFire;
+  constructor(snap: DataSnapshot, nodeFire: AnyNodeFire) {
     this.$snap = snap;
     this.$nodeFire = nodeFire;
   }
@@ -776,7 +838,7 @@ export class Snapshot<Root> {
     return this.$snap.key;
   }
 
-  get ref(): NodeFire {
+  get ref(): AnyNodeFire {
     return new NodeFire(this.$snap.ref, this.$nodeFire.$scope);
   }
 
@@ -824,7 +886,7 @@ type CapturableCallback<T> =
 // wrappers is equal to the number of on()s for that callback, and we can safely pop one with each
 // call to off().
 function captureCallback<T>(
-  nodeFire: NodeFire,
+  nodeFire: AnyNodeFire,
   eventType: EventType,
   callback: CapturableCallback<T>,
 ): (a: DataSnapshot, b?: string) => any {
@@ -840,7 +902,7 @@ function captureCallback<T>(
 }
 
 function popCallback<T>(
-  nodeFire: NodeFire, eventType: EventType | undefined,
+  nodeFire: AnyNodeFire, eventType: EventType | undefined,
   callback: CapturableCallback<T>
 ): NodeFireCallback {
   const key = eventType + '::' + nodeFire.toString();
@@ -866,7 +928,7 @@ function delegateSnapshot(method) {
   };
 }
 
-function wrapReject(nodefire: NodeFire, method, value, reject?) {
+function wrapReject(nodefire: AnyNodeFire, method, value, reject?) {
   let hasValue = true;
   if (!reject) {
     reject = value;
@@ -1066,6 +1128,181 @@ type ResultFor<Root, P extends string> =
     unknown :
     // If P is a literal (or union of literals), be strict and use branded error on failure
     BrandedLookup<Root, P>;
+
+interface UnknownParent {
+  readonly unknownParent: true;
+}
+type NodeFireParents =
+  null |
+  UnknownParent |
+  readonly [readRoot: unknown, writeRoot: unknown, parents: NodeFireParents];
+
+type IsAny<T> = 0 extends (1 & T) ? true : false;
+type DefaultParents<Root> = IsAny<Root> extends true ? UnknownParent : null;
+
+declare const NAVIGATION: unique symbol;
+interface NodeFireNavigation<
+  DatabaseRoot,
+  WriteDatabaseRoot,
+  Parents extends NodeFireParents
+> {
+  readonly [NAVIGATION]: readonly [DatabaseRoot, WriteDatabaseRoot, Parents];
+}
+
+type NavigatedNodeFire<
+  Root,
+  WriteSpecialRules extends readonly WriteSpecialRule<any, any, any>[],
+  WriteRoot,
+  DatabaseRoot,
+  WriteDatabaseRoot,
+  Parents extends NodeFireParents
+> = NodeFire<Root, WriteSpecialRules, WriteRoot> &
+  NodeFireNavigation<DatabaseRoot, WriteDatabaseRoot, Parents>;
+
+type NavigationStateFor<This, Root, WriteRoot> =
+  This extends NodeFireNavigation<
+    infer DatabaseRoot,
+    infer WriteDatabaseRoot,
+    infer Parents
+  > ?
+    readonly [DatabaseRoot, WriteDatabaseRoot, Parents] :
+    readonly [Root, WriteRoot, DefaultParents<Root>];
+
+type SameNodeFire<
+  This,
+  Root,
+  WriteSpecialRules extends readonly WriteSpecialRule<any, any, any>[],
+  WriteRoot
+> = This extends NodeFireNavigation<
+  infer DatabaseRoot,
+  infer WriteDatabaseRoot,
+  infer Parents
+> ?
+  NavigatedNodeFire<
+    Root, WriteSpecialRules, WriteRoot,
+    DatabaseRoot, WriteDatabaseRoot, Parents
+  > :
+  NodeFire<Root, WriteSpecialRules, WriteRoot>;
+
+type RootNodeFire<
+  This,
+  Root,
+  WriteSpecialRules extends readonly WriteSpecialRule<any, any, any>[],
+  WriteRoot
+> = NavigationStateFor<This, Root, WriteRoot> extends readonly [
+  infer DatabaseRoot,
+  infer WriteDatabaseRoot,
+  NodeFireParents
+] ?
+  NavigatedNodeFire<
+    DatabaseRoot, WriteSpecialRules, WriteDatabaseRoot,
+    DatabaseRoot, WriteDatabaseRoot, null
+  > :
+  never;
+
+type ChildParents<
+  Root,
+  WriteRoot,
+  P extends string,
+  Parents extends NodeFireParents
+> = string extends P ?
+  UnknownParent :
+  BuildChildParents<Root, WriteRoot, NormalizeParts<Split<P>>, Parents>;
+
+type BuildChildParents<
+  Root,
+  WriteRoot,
+  Parts extends readonly string[],
+  Parents extends NodeFireParents
+> = Parts extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[]
+] ?
+  BuildChildParents<
+    ReadResultFor<Root, Head>, ResultFor<WriteRoot, Head>, Tail,
+    readonly [Root, WriteRoot, Parents]
+  > :
+  Parents;
+
+type ParentNodeFire<
+  This,
+  Root,
+  WriteSpecialRules extends readonly WriteSpecialRule<any, any, any>[],
+  WriteRoot
+> = NavigationStateFor<This, Root, WriteRoot> extends readonly [
+  infer DatabaseRoot,
+  infer WriteDatabaseRoot,
+  infer Parents extends NodeFireParents
+] ?
+  ParentNodeFireFromState<
+    WriteSpecialRules, DatabaseRoot, WriteDatabaseRoot, Parents
+  > :
+  never;
+
+type ParentNodeFireFromState<
+  WriteSpecialRules extends readonly WriteSpecialRule<any, any, any>[],
+  DatabaseRoot,
+  WriteDatabaseRoot,
+  Parents extends NodeFireParents
+> = Parents extends UnknownParent ?
+  NavigatedNodeFire<
+    unknown, WriteSpecialRules, unknown,
+    DatabaseRoot, WriteDatabaseRoot, UnknownParent
+  > :
+  Parents extends readonly [
+    infer ParentRoot,
+    infer ParentWriteRoot,
+    infer Grandparents extends NodeFireParents
+  ] ?
+  NavigatedNodeFire<
+    ParentRoot, WriteSpecialRules, ParentWriteRoot,
+    DatabaseRoot, WriteDatabaseRoot, Grandparents
+  > :
+  never;
+
+type ChildNodeFire<
+  This,
+  Root,
+  WriteSpecialRules extends readonly WriteSpecialRule<any, any, any>[],
+  WriteRoot,
+  P extends string
+> = NavigationStateFor<This, Root, WriteRoot> extends readonly [
+  infer DatabaseRoot,
+  infer WriteDatabaseRoot,
+  infer Parents extends NodeFireParents
+] ?
+  NavigatedNodeFire<
+    ReadResultFor<Root, P>, WriteSpecialRules, ResultFor<WriteRoot, P>,
+    DatabaseRoot, WriteDatabaseRoot, ChildParents<Root, WriteRoot, P, Parents>
+  > :
+  never;
+
+export type ChildNodeFireOf<
+  This extends NodeFireTypeCarrier,
+  P extends string
+> = ChildNodeFire<
+  This,
+  This[typeof NODE_FIRE_TYPES][0],
+  This[typeof NODE_FIRE_TYPES][1],
+  This[typeof NODE_FIRE_TYPES][2],
+  P
+>;
+
+type PushedNodeFire<
+  This,
+  Root,
+  WriteSpecialRules extends readonly WriteSpecialRule<any, any, any>[],
+  WriteRoot
+> = NavigationStateFor<This, Root, WriteRoot> extends readonly [
+  infer DatabaseRoot,
+  infer WriteDatabaseRoot,
+  infer Parents extends NodeFireParents
+] ?
+  NavigatedNodeFire<
+    PushValue<Root>, WriteSpecialRules, PushValue<WriteRoot>,
+    DatabaseRoot, WriteDatabaseRoot, readonly [Root, WriteRoot, Parents]
+  > :
+  never;
 
 type WriteSpecialRule<
   KeyPattern extends string = string,

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "noEmit": true,
+    "rootDir": ".."
+  },
+  "include": ["types.ts"],
+  "exclude": []
+}

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,0 +1,161 @@
+import type {Reference} from 'firebase-admin/database';
+import NodeFire, {type ChildNodeFireOf} from '../src';
+
+type Equal<Left, Right> =
+  (<T>() => T extends Left ? 1 : 2) extends
+  (<T>() => T extends Right ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+type GetResult<T extends {get: (...args: any[]) => Promise<unknown>}> =
+  Awaited<ReturnType<T['get']>>;
+
+interface User {
+  displayName: string;
+  loginCount: number;
+}
+
+interface Organization {
+  name: string;
+  users: {$: User};
+}
+
+interface Database {
+  organizations: {$: Organization};
+  settings: {featureEnabled: boolean};
+}
+
+declare const reference: Reference;
+const untyped = new NodeFire(reference);
+type UntypedParentResult = Expect<
+  Equal<GetResult<NonNullable<typeof untyped.parent>>, unknown>
+>;
+const db = new NodeFire<Database>(reference);
+const unusedTypedAsUntyped: NodeFire = db;
+const unusedUntypedAsTyped: NodeFire<Database> = untyped;
+
+const user = db.child('organizations/:organization/users/:user');
+type UserResult = Expect<Equal<GetResult<typeof user>, User | null>>;
+type InferredUser = Expect<Equal<
+  typeof user extends NodeFire<
+    infer Current, infer unusedRules, infer unusedWrite
+  > ? Current : never,
+  User
+>>;
+type UsersRef = NonNullable<typeof user.parent>;
+type UsersResult = Expect<Equal<GetResult<UsersRef>, Organization['users'] | null>>;
+type OrganizationRef = NonNullable<UsersRef['parent']>;
+type OrganizationResult = Expect<Equal<GetResult<OrganizationRef>, Organization | null>>;
+type OrganizationsRef = NonNullable<OrganizationRef['parent']>;
+type OrganizationsResult = Expect<
+  Equal<GetResult<OrganizationsRef>, Database['organizations'] | null>
+>;
+type DatabaseRef = NonNullable<OrganizationsRef['parent']>;
+type DatabaseResult = Expect<Equal<GetResult<DatabaseRef>, Database | null>>;
+type RootParent = Expect<Equal<DatabaseRef['parent'], null>>;
+
+type RootResult = Expect<Equal<GetResult<typeof user.root>, Database | null>>;
+type NavigatedRootParent = Expect<Equal<(typeof user.root)['parent'], null>>;
+const unusedSettings = user.root.child('settings');
+type SettingsResult = Expect<
+  Equal<GetResult<typeof unusedSettings>, Database['settings'] | null>
+>;
+
+void user.root.set({
+  organizations: {
+    $: {name: 'Acme', users: {$: {displayName: 'Ada', loginCount: 1}}}
+  },
+  settings: {featureEnabled: true}
+});
+void user.parent?.set({$: {displayName: 'Ada', loginCount: 1}});
+// @ts-expect-error The root reference must use the database write type, not the child write type.
+void user.root.set({displayName: 'Ada', loginCount: 1});
+// @ts-expect-error The parent reference must use the users write type, not the organization type.
+void user.parent?.set({name: 'Acme', users: {$: {displayName: 'Ada', loginCount: 1}}});
+
+const unusedChainedUser = db
+  .child('organizations/:organization')
+  .child('users/:user');
+type ChainedParentResult = Expect<
+  Equal<GetResult<NonNullable<typeof unusedChainedUser.parent>>, Organization['users'] | null>
+>;
+type ChainedGrandparentResult = Expect<
+  Equal<
+    GetResult<NonNullable<NonNullable<typeof unusedChainedUser.parent>['parent']>>,
+    Organization | null
+  >
+>;
+
+const unusedQueriedUser = user.orderByKey().limitToFirst(1).ref.scope({organization: 'acme'});
+type QueryParentResult = Expect<
+  Equal<GetResult<NonNullable<typeof unusedQueriedUser.parent>>, Organization['users'] | null>
+>;
+type QueryRootResult = Expect<Equal<GetResult<typeof unusedQueriedUser.root>, Database | null>>;
+
+declare const runtimePath: string;
+const unusedDynamicRef = db.child(runtimePath);
+type DynamicResult = Expect<Equal<GetResult<typeof unusedDynamicRef>, unknown>>;
+type DynamicParentResult = Expect<
+  Equal<GetResult<NonNullable<typeof unusedDynamicRef.parent>>, unknown>
+>;
+type DynamicRootResult = Expect<Equal<GetResult<typeof unusedDynamicRef.root>, Database | null>>;
+
+const users = db.child('organizations/:organization/users');
+type RecreatedUsers = typeof users extends NodeFire<
+  infer Current, infer Rules, infer WriteCurrent
+> ? NodeFire<Current, Rules, WriteCurrent> : never;
+type CompatibleRecreatedUsers = Expect<typeof users extends RecreatedUsers ? true : false>;
+const unusedPushedUser = users.push({displayName: 'Ada', loginCount: 1});
+type PushedUserRef = Awaited<typeof unusedPushedUser>;
+type PushedUserResult = Expect<Equal<GetResult<PushedUserRef>, User | null>>;
+type PushedParentResult = Expect<
+  Equal<GetResult<NonNullable<PushedUserRef['parent']>>, Organization['users'] | null>
+>;
+type PushedRootResult = Expect<Equal<GetResult<PushedUserRef['root']>, Database | null>>;
+
+function childAtRuntimeKey<Node extends NodeFire<any, readonly any[], any>>(
+  node: Node,
+  key: string
+): ChildNodeFireOf<Node, '$'> {
+  return node.child<'$'>(key);
+}
+
+const organizations = db.child('organizations');
+const unusedOrganization = childAtRuntimeKey(organizations, 'acme');
+
+type RuntimeOrganizationResult = Expect<
+  Equal<GetResult<typeof unusedOrganization>, Organization | null>
+>;
+
+type RuntimeOrganizationParentResult = Expect<
+  Equal<
+    GetResult<NonNullable<typeof unusedOrganization.parent>>,
+    Database['organizations'] | null
+  >
+>;
+
+// Ensure the aliases above are checked even when noUnusedLocals is enabled.
+export type NavigationTypeTests = [
+  UntypedParentResult,
+  UserResult,
+  InferredUser,
+  UsersResult,
+  OrganizationResult,
+  OrganizationsResult,
+  DatabaseResult,
+  RootParent,
+  RootResult,
+  NavigatedRootParent,
+  SettingsResult,
+  ChainedParentResult,
+  ChainedGrandparentResult,
+  QueryParentResult,
+  QueryRootResult,
+  DynamicResult,
+  DynamicParentResult,
+  DynamicRootResult,
+  CompatibleRecreatedUsers,
+  PushedUserResult,
+  PushedParentResult,
+  PushedRootResult,
+  RuntimeOrganizationResult,
+  RuntimeOrganizationParentResult
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3145,7 +3145,7 @@ __metadata:
     npm-check-updates: "npm:^22.2.9"
     reviewable-configs: "Reviewable/reviewable-configs#master"
     safe-timers: "npm:^1.1.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:^5.4.0"
   languageName: unknown
   linkType: soft
 
@@ -4016,7 +4016,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.3.3":
+"typescript@npm:^5.4.0":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -4026,7 +4026,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.4.0#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:


### PR DESCRIPTION
## Summary

- preserve database-root read and write types while navigating through `child()`
- track each path segment so `parent` restores the immediate parent type and `root` restores the database type
- retain navigation state through queries, `ref`, `scope`, and `push`, with safe `unknown` fallback for dynamic paths
- preserve raw non-generic `NodeFire` compatibility and existing `NodeFire<infer ...>` patterns
- add lint-clean compile-time regression coverage and document typed navigation

## Root cause

`child()` specialized the current value and write types, but `root` and `parent` simply reused those specialized generics. After navigating to a child, their runtime references were correct while their TypeScript types still described the child.

## Compatibility

This updates the package to 7.0.0 because the corrected navigation types can expose previously hidden type errors. Raw `NodeFire` usage remains supported. The type declarations now require TypeScript 5.4 for `NoInfer`.

## Validation

- `yarn lint`
- `yarn check-types`
- `yarn build`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/nodefire/54)
<!-- Reviewable:end -->
