### PR TITLE
Track ancestor cache hits and expose cache stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,19 +151,32 @@ static setCacheSize(max)
 /**
  * Gets the current number of values pinned in the cache.
  * @return {number} The current size of the cache.
+ * @deprecated Use `getCacheStats().count` instead.
  */
 static getCacheCount()
 
 /**
- * Gets the current cache hit rate.  This is very approximate, as it's only counted for get() and
- * transaction() calls, and is unable to count ancestor hits, where the ancestor of the requested
- * item is actually cached.
+ * Gets the current cache statistics.
+ * @return The current cache statistics as `{count, maxSize, hits, misses, hitRate}`.  Hits include
+ *     requests covered by a cached ancestor.
+ */
+static getCacheStats()
+
+/**
+ * Gets the current cache hit rate.
  * @return {number} The cache's current hit rate.
+ * @deprecated Use `getCacheStats().hitRate` instead.
  */
 static getCacheHitRate()
 
 /**
- * Resets the cache's hit rate counters back to zero.
+ * Resets the cache's hit and miss counters back to zero.
+ */
+static resetCacheStats()
+
+/**
+ * Resets the cache's hit and miss counters back to zero.
+ * @deprecated Use `resetCacheStats()` instead.
  */
 static resetCacheHitRate()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodefire",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "A promise-centric Firebase library for NodeJS",
   "main": "built/index.js",
   "types": "built/index.d.ts",
@@ -15,9 +15,10 @@
     "update": "yarn up -R '*' && yarn dedupe --strategy highest",
     "latest": "yarn npm-check-updates -i -m --packageManager yarn --install never && yarn install",
     "upgrade": "reviewable-upgrade",
-    "lint": "eslint src/*.ts tests/*.ts",
+    "lint": "eslint src/*.ts tests/*.ts tests/*.mjs",
     "check-types": "tsc --noEmit --skipLibCheck && tsc --project tests/tsconfig.json --skipLibCheck",
     "build": "tsc",
+    "test": "yarn build && node --test tests/cache.mjs",
     "prepack": "tsc"
   },
   "repository": "https://github.com/Reviewable/nodefire",

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -351,10 +351,12 @@ export default class NodeFire<
     if (!cache) return;
     if (!this.$ref.isEqual(this.$ref.ref)) return;  // don't cache queries
     const keyPrefix = getCacheKeyPrefix(this);
+    const key = keyPrefix + this.path;
     let isHit = false;
     let cachedPath = this.path;
     while (true) {
-      if (cache.get(keyPrefix + cachedPath)) {
+      // Probe ancestors without changing their LRU recency.
+      if (cache.has(keyPrefix + cachedPath)) {
         cacheHits++;
         isHit = true;
         break;
@@ -362,9 +364,12 @@ export default class NodeFire<
       if (cachedPath === '/') break;
       cachedPath = cachedPath.slice(0, cachedPath.lastIndexOf('/')) || '/';
     }
-    if (!isHit) cacheMisses++;
-    else if (cachedPath === this.path) return;
-    const key = keyPrefix + this.path;
+    if (!isHit) {
+      cacheMisses++;
+    } else if (cachedPath === this.path) {
+      cache.get(key);  // refresh recency without adding another listener
+      return;
+    }
     cache.set(key, this);
     this.$ref.on('value', noopCallback, () => {
       if (cache) cache.delete(key);

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -42,7 +42,7 @@ export interface CacheStats {
   maxSize: number;
   /** The number of cache attempts satisfied by the requested path or one of its ancestors. */
   hits: number;
-  /** The number of cache attempts that added the requested path to the cache. */
+  /** The number of cache attempts with no cached requested path or ancestor. */
   misses: number;
   /** `hits / (hits + misses)`, or zero if there have been no attempts. */
   hitRate: number;
@@ -350,17 +350,20 @@ export default class NodeFire<
   cache(): void {
     if (!cache) return;
     if (!this.$ref.isEqual(this.$ref.ref)) return;  // don't cache queries
-    const keyPrefix = this.database.app.name + '/';
+    const keyPrefix = getCacheKeyPrefix(this);
+    let isHit = false;
     let cachedPath = this.path;
     while (true) {
       if (cache.get(keyPrefix + cachedPath)) {
         cacheHits++;
-        return;
+        isHit = true;
+        break;
       }
       if (cachedPath === '/') break;
       cachedPath = cachedPath.slice(0, cachedPath.lastIndexOf('/')) || '/';
     }
-    cacheMisses++;
+    if (!isHit) cacheMisses++;
+    if (isHit && cachedPath === this.path) return;
     const key = keyPrefix + this.path;
     cache.set(key, this);
     this.$ref.on('value', noopCallback, () => {
@@ -374,7 +377,7 @@ export default class NodeFire<
    */
   uncache(): undefined | boolean {
     if (!cache) return;
-    const key = this.database.app.name + '/' + this.path;
+    const key = getCacheKeyPrefix(this) + this.path;
     if (!cache.has(key)) return false;
     cache.delete(key);
     return true;
@@ -742,7 +745,7 @@ export default class NodeFire<
    * @deprecated Use `getCacheStats().count` instead.
    */
   static getCacheCount(): number {
-    return this.getCacheStats().count;
+    return NodeFire.getCacheStats().count;
   }
 
   /**
@@ -765,7 +768,7 @@ export default class NodeFire<
    * @deprecated Use `getCacheStats().hitRate` instead.
    */
   static getCacheHitRate(): number {
-    return this.getCacheStats().hitRate;
+    return NodeFire.getCacheStats().hitRate;
   }
 
   /**
@@ -780,7 +783,7 @@ export default class NodeFire<
    * @deprecated Use `resetCacheStats()` instead.
    */
   static resetCacheHitRate(): void {
-    this.resetCacheStats();
+    NodeFire.resetCacheStats();
   }
 
   /**
@@ -988,6 +991,10 @@ function wrapReject(nodefire: AnyNodeFire, method, value, reject?) {
 }
 
 function noopCallback() {/* empty */}
+
+function getCacheKeyPrefix(ref: AnyNodeFire): string {
+  return ref.database.app.name + '/' + ref.$ref.ref.root.toString();
+}
 
 function trackTimeOffset(ref, recover = false) {
   const appName = ref.database.app.name;

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -363,7 +363,7 @@ export default class NodeFire<
       cachedPath = cachedPath.slice(0, cachedPath.lastIndexOf('/')) || '/';
     }
     if (!isHit) cacheMisses++;
-    if (isHit && cachedPath === this.path) return;
+    else if (cachedPath === this.path) return;
     const key = keyPrefix + this.path;
     cache.set(key, this);
     this.$ref.on('value', noopCallback, () => {

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -35,6 +35,19 @@ export type NormalizedValue<T> =
   T;
 export type ReadValue<T> = Exclude<NormalizedValue<T>, undefined>;
 
+export interface CacheStats {
+  /** The current number of values pinned in the cache. */
+  count: number;
+  /** The maximum number of values that can be pinned in the cache, or zero if it is disabled. */
+  maxSize: number;
+  /** The number of cache attempts satisfied by the requested path or one of its ancestors. */
+  hits: number;
+  /** The number of cache attempts that added the requested path to the cache. */
+  misses: number;
+  /** `hits / (hits + misses)`, or zero if there have been no attempts. */
+  hitRate: number;
+}
+
 let cache: LRUCache<string, AnyNodeFire> | null;
 let cacheHits = 0, cacheMisses = 0;
 const serverTimeOffsets = {}, serverDisconnects = {}, simulators = {};
@@ -337,16 +350,22 @@ export default class NodeFire<
   cache(): void {
     if (!cache) return;
     if (!this.$ref.isEqual(this.$ref.ref)) return;  // don't cache queries
-    const key = this.database.app.name + '/' + this.path;
-    if (cache.get(key)) {
-      cacheHits++;
-    } else {
-      cacheMisses++;
-      cache.set(key, this);
-      this.$ref.on('value', noopCallback, () => {
-        if (cache) cache.delete(key);
-      });
+    const keyPrefix = this.database.app.name + '/';
+    let cachedPath = this.path;
+    while (true) {
+      if (cache.get(keyPrefix + cachedPath)) {
+        cacheHits++;
+        return;
+      }
+      if (cachedPath === '/') break;
+      cachedPath = cachedPath.slice(0, cachedPath.lastIndexOf('/')) || '/';
     }
+    cacheMisses++;
+    const key = keyPrefix + this.path;
+    cache.set(key, this);
+    this.$ref.on('value', noopCallback, () => {
+      if (cache) cache.delete(key);
+    });
   }
 
   /**
@@ -720,26 +739,48 @@ export default class NodeFire<
   /**
    * Gets the current number of values pinned in the cache.
    * @return {number} The current size of the cache.
+   * @deprecated Use `getCacheStats().count` instead.
    */
   static getCacheCount(): number {
-    return cache ? cache.size : 0;
+    return this.getCacheStats().count;
   }
 
   /**
-   * Gets the current cache hit rate.  This is very approximate, as it's only counted for get() and
-   * transaction() calls, and is unable to count ancestor hits, where the ancestor of the requested
-   * item is actually cached.
+   * Gets the current cache statistics.
+   * @return The current cache size and maximum, as well as its hit and miss counts and hit rate.
+   */
+  static getCacheStats(): CacheStats {
+    return {
+      count: cache ? cache.size : 0,
+      maxSize: cache ? cache.max : 0,
+      hits: cacheHits,
+      misses: cacheMisses,
+      hitRate: (cacheHits || cacheMisses) ? cacheHits / (cacheHits + cacheMisses) : 0
+    };
+  }
+
+  /**
+   * Gets the current cache hit rate.
    * @return {number} The cache's current hit rate.
+   * @deprecated Use `getCacheStats().hitRate` instead.
    */
   static getCacheHitRate(): number {
-    return (cacheHits || cacheMisses) ? cacheHits / (cacheHits + cacheMisses) : 0;
+    return this.getCacheStats().hitRate;
+  }
+
+  /**
+   * Resets the cache's hit and miss counters back to zero.
+   */
+  static resetCacheStats(): void {
+    cacheHits = cacheMisses = 0;
   }
 
   /**
    * Resets the cache's hit rate counters back to zero.
+   * @deprecated Use `resetCacheStats()` instead.
    */
   static resetCacheHitRate(): void {
-    cacheHits = cacheMisses = 0;
+    this.resetCacheStats();
   }
 
   /**

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -1013,9 +1013,9 @@ function trackTimeOffset(ref, recover = false) {
 }
 
 function trackDisconnect(ref, recover = false) {
-  const appName = ref.database.app.name;
-  if (!recover && serverDisconnects[appName]) return;
-  serverDisconnects[appName] = true;
+  const databaseKey = getCacheKeyPrefix(ref);
+  if (!recover && serverDisconnects[databaseKey]) return;
+  serverDisconnects[databaseKey] = true;
   ref.root.child('.info/connected').on('value', snap => {
     if (!snap.val()) trimCache(ref);
   }, _.bind(trackDisconnect, ref, true));
@@ -1023,7 +1023,7 @@ function trackDisconnect(ref, recover = false) {
 
 function trimCache(ref) {
   if (!cache) return;
-  const prefix = ref.database.app.name + '/';
+  const prefix = getCacheKeyPrefix(ref);
   // eslint-disable-next-line lodash/prefer-lodash-method
   cache.forEach((value, key) => {
     if (_.startsWith(key, prefix)) cache!.delete(key);

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -998,7 +998,7 @@ function wrapReject(nodefire: AnyNodeFire, method, value, reject?) {
 function noopCallback() {/* empty */}
 
 function getCacheKeyPrefix(ref: AnyNodeFire): string {
-  return ref.database.app.name + '/' + ref.$ref.ref.root.toString();
+  return ref.database.app.name + '\0' + ref.$ref.ref.root.toString() + '\0';
 }
 
 function trackTimeOffset(ref, recover = false) {

--- a/tests/cache.mjs
+++ b/tests/cache.mjs
@@ -11,11 +11,13 @@ class FakeReference {
     path = '/',
     appName = `cache-test-${++appCounter}`,
     databaseName = appName,
-    valueListenerAdds = new Map()
+    valueListenerAdds = new Map(),
+    connectedCallbacks = []
   ) {
     this.path = path;
     this.databaseName = databaseName;
     this.valueListenerAdds = valueListenerAdds;
+    this.connectedCallbacks = connectedCallbacks;
     this.database = {app: {name: appName}};
   }
 
@@ -27,7 +29,8 @@ class FakeReference {
     if (this.path === '/') return null;
     const path = this.path.slice(0, this.path.lastIndexOf('/')) || '/';
     return new FakeReference(
-      path, this.database.app.name, this.databaseName, this.valueListenerAdds
+      path, this.database.app.name, this.databaseName,
+      this.valueListenerAdds, this.connectedCallbacks
     );
   }
 
@@ -37,14 +40,16 @@ class FakeReference {
 
   get root() {
     return new FakeReference(
-      '/', this.database.app.name, this.databaseName, this.valueListenerAdds
+      '/', this.database.app.name, this.databaseName,
+      this.valueListenerAdds, this.connectedCallbacks
     );
   }
 
   child(childPath) {
     const path = this.path === '/' ? `/${childPath}` : `${this.path}/${childPath}`;
     return new FakeReference(
-      path, this.database.app.name, this.databaseName, this.valueListenerAdds
+      path, this.database.app.name, this.databaseName,
+      this.valueListenerAdds, this.connectedCallbacks
     );
   }
 
@@ -68,9 +73,14 @@ class FakeReference {
       callback({val: () => 0});
     }
     if (this.path === '/.info/connected') {
+      this.connectedCallbacks.push(callback);
       // eslint-disable-next-line lodash/prefer-constant
       callback({val: () => true});
     }
+  }
+
+  emitConnected(value) {
+    for (const callback of this.connectedCallbacks) callback({val: () => value});
   }
 
   toString() {
@@ -215,4 +225,23 @@ test('does not refresh ancestor recency while checking for indirect hits', () =>
   assert.equal(ancestor.uncache(), false);
   assert.equal(other.uncache(), true);
   assert.equal(descendant.uncache(), true);
+});
+
+test('tracks disconnects and trims the cache per database instance', () => {
+  NodeFire.setCacheSize(10);
+  const firstReference = new FakeReference('/', 'disconnect-app', 'first-database');
+  const secondReference = new FakeReference('/', 'disconnect-app', 'second-database');
+  const first = new NodeFire(firstReference).childRaw('value');
+  const second = new NodeFire(secondReference).childRaw('value');
+
+  first.cache();
+  second.cache();
+  firstReference.emitConnected(false);
+
+  assert.equal(first.uncache(), false);
+  assert.equal(second.uncache(), true);
+
+  second.cache();
+  secondReference.emitConnected(false);
+  assert.equal(second.uncache(), false);
 });

--- a/tests/cache.mjs
+++ b/tests/cache.mjs
@@ -10,10 +10,12 @@ class FakeReference {
   constructor(
     path = '/',
     appName = `cache-test-${++appCounter}`,
-    databaseName = appName
+    databaseName = appName,
+    valueListenerAdds = new Map()
   ) {
     this.path = path;
     this.databaseName = databaseName;
+    this.valueListenerAdds = valueListenerAdds;
     this.database = {app: {name: appName}};
   }
 
@@ -24,7 +26,9 @@ class FakeReference {
   get parent() {
     if (this.path === '/') return null;
     const path = this.path.slice(0, this.path.lastIndexOf('/')) || '/';
-    return new FakeReference(path, this.database.app.name, this.databaseName);
+    return new FakeReference(
+      path, this.database.app.name, this.databaseName, this.valueListenerAdds
+    );
   }
 
   get ref() {
@@ -32,12 +36,16 @@ class FakeReference {
   }
 
   get root() {
-    return new FakeReference('/', this.database.app.name, this.databaseName);
+    return new FakeReference(
+      '/', this.database.app.name, this.databaseName, this.valueListenerAdds
+    );
   }
 
   child(childPath) {
     const path = this.path === '/' ? `/${childPath}` : `${this.path}/${childPath}`;
-    return new FakeReference(path, this.database.app.name, this.databaseName);
+    return new FakeReference(
+      path, this.database.app.name, this.databaseName, this.valueListenerAdds
+    );
   }
 
   isEqual(other) {
@@ -51,6 +59,10 @@ class FakeReference {
   off() {/* Nothing to detach in the fake reference. */}
 
   on(event, callback) {
+    // eslint-disable-next-line lodash/prefer-lodash-method
+    if (event === 'value' && !this.path.startsWith('/.info/')) {
+      this.valueListenerAdds.set(this.path, (this.valueListenerAdds.get(this.path) || 0) + 1);
+    }
     if (this.path === '/.info/serverTimeOffset') {
       // eslint-disable-next-line lodash/prefer-constant
       callback({val: () => 0});
@@ -170,4 +182,37 @@ test('keeps deprecated cache methods callable without a receiver', () => {
     misses: 0,
     hitRate: 0
   });
+});
+
+test('refreshes direct hits without adding duplicate value listeners', () => {
+  NodeFire.setCacheSize(2);
+  const reference = new FakeReference();
+  const root = new NodeFire(reference);
+  const first = root.childRaw('first');
+  const second = root.childRaw('second');
+
+  first.cache();
+  second.cache();
+  first.cache();
+  root.childRaw('third').cache();
+
+  assert.equal(reference.valueListenerAdds.get('/first'), 1);
+  assert.equal(second.uncache(), false);
+  assert.equal(first.uncache(), true);
+});
+
+test('does not refresh ancestor recency while checking for indirect hits', () => {
+  NodeFire.setCacheSize(2);
+  const root = new NodeFire(new FakeReference());
+  const ancestor = root.childRaw('parent');
+  const other = root.childRaw('other');
+  const descendant = root.childRaw('parent/child');
+
+  ancestor.cache();
+  other.cache();
+  descendant.cache();
+
+  assert.equal(ancestor.uncache(), false);
+  assert.equal(other.uncache(), true);
+  assert.equal(descendant.uncache(), true);
 });

--- a/tests/cache.mjs
+++ b/tests/cache.mjs
@@ -7,8 +7,13 @@ const {default: NodeFire} = NodeFireModule;
 let appCounter = 0;
 
 class FakeReference {
-  constructor(path = '/', appName = `cache-test-${++appCounter}`) {
+  constructor(
+    path = '/',
+    appName = `cache-test-${++appCounter}`,
+    databaseName = appName
+  ) {
     this.path = path;
+    this.databaseName = databaseName;
     this.database = {app: {name: appName}};
   }
 
@@ -19,7 +24,7 @@ class FakeReference {
   get parent() {
     if (this.path === '/') return null;
     const path = this.path.slice(0, this.path.lastIndexOf('/')) || '/';
-    return new FakeReference(path, this.database.app.name);
+    return new FakeReference(path, this.database.app.name, this.databaseName);
   }
 
   get ref() {
@@ -27,16 +32,20 @@ class FakeReference {
   }
 
   get root() {
-    return new FakeReference('/', this.database.app.name);
+    return new FakeReference('/', this.database.app.name, this.databaseName);
   }
 
   child(childPath) {
     const path = this.path === '/' ? `/${childPath}` : `${this.path}/${childPath}`;
-    return new FakeReference(path, this.database.app.name);
+    return new FakeReference(path, this.database.app.name, this.databaseName);
   }
 
   isEqual(other) {
-    return this.database.app.name === other.database.app.name && this.path === other.path;
+    return (
+      this.database.app.name === other.database.app.name &&
+      this.databaseName === other.databaseName &&
+      this.path === other.path
+    );
   }
 
   off() {/* Nothing to detach in the fake reference. */}
@@ -53,7 +62,7 @@ class FakeReference {
   }
 
   toString() {
-    return `https://${this.database.app.name}.test${this.path}`;
+    return `https://${this.databaseName}.test${this.path}`;
   }
 
   transaction() {/* The constructor only checks that this method exists. */}
@@ -67,18 +76,20 @@ afterEach(() => {
 test('counts a cached ancestor as a cache hit', () => {
   NodeFire.setCacheSize(10);
   const root = new NodeFire(new FakeReference());
+  const descendant = root.childRaw('parent/child/grandchild');
 
   root.childRaw('parent').cache();
-  root.childRaw('parent/child/grandchild').cache();
+  descendant.cache();
 
   assert.deepEqual(NodeFire.getCacheStats(), {
-    count: 1,
+    count: 2,
     maxSize: 10,
     hits: 1,
     misses: 1,
     hitRate: 0.5
   });
 
+  assert.equal(descendant.uncache(), true);
   NodeFire.resetCacheStats();
   assert.deepEqual(NodeFire.getCacheStats(), {
     count: 1,
@@ -98,11 +109,28 @@ test('counts the cached root as a cache hit for descendants', () => {
   root.childRaw('child/grandchild').cache();
 
   assert.deepEqual(NodeFire.getCacheStats(), {
-    count: 1,
+    count: 2,
     maxSize: 10,
     hits: 1,
     misses: 1,
     hitRate: 0.5
+  });
+});
+
+test('scopes ancestor cache hits to the database instance', () => {
+  NodeFire.setCacheSize(10);
+  const firstRoot = new NodeFire(new FakeReference('/', 'shared-app', 'first-database'));
+  const secondRoot = new NodeFire(new FakeReference('/', 'shared-app', 'second-database'));
+
+  firstRoot.childRaw('parent').cache();
+  secondRoot.childRaw('parent/child').cache();
+
+  assert.deepEqual(NodeFire.getCacheStats(), {
+    count: 2,
+    maxSize: 10,
+    hits: 0,
+    misses: 2,
+    hitRate: 0
   });
 });
 
@@ -118,6 +146,28 @@ test('counts unrelated paths as cache misses', () => {
     maxSize: 10,
     hits: 0,
     misses: 2,
+    hitRate: 0
+  });
+});
+
+test('keeps deprecated cache methods callable without a receiver', () => {
+  NodeFire.setCacheSize(10);
+  const root = new NodeFire(new FakeReference());
+  root.cache();
+  root.cache();
+
+  const getCacheCount = NodeFire.getCacheCount;
+  const getCacheHitRate = NodeFire.getCacheHitRate;
+  const resetCacheHitRate = NodeFire.resetCacheHitRate;
+
+  assert.equal(getCacheCount(), 1);
+  assert.equal(getCacheHitRate(), 0.5);
+  resetCacheHitRate();
+  assert.deepEqual(NodeFire.getCacheStats(), {
+    count: 1,
+    maxSize: 10,
+    hits: 0,
+    misses: 0,
     hitRate: 0
   });
 });

--- a/tests/cache.mjs
+++ b/tests/cache.mjs
@@ -12,10 +12,12 @@ class FakeReference {
     appName = `cache-test-${++appCounter}`,
     databaseName = appName,
     valueListenerAdds = new Map(),
-    connectedCallbacks = []
+    connectedCallbacks = [],
+    databaseRoot = `https://${databaseName}.test`
   ) {
     this.path = path;
     this.databaseName = databaseName;
+    this.databaseRoot = databaseRoot;
     this.valueListenerAdds = valueListenerAdds;
     this.connectedCallbacks = connectedCallbacks;
     this.database = {app: {name: appName}};
@@ -30,7 +32,7 @@ class FakeReference {
     const path = this.path.slice(0, this.path.lastIndexOf('/')) || '/';
     return new FakeReference(
       path, this.database.app.name, this.databaseName,
-      this.valueListenerAdds, this.connectedCallbacks
+      this.valueListenerAdds, this.connectedCallbacks, this.databaseRoot
     );
   }
 
@@ -41,7 +43,7 @@ class FakeReference {
   get root() {
     return new FakeReference(
       '/', this.database.app.name, this.databaseName,
-      this.valueListenerAdds, this.connectedCallbacks
+      this.valueListenerAdds, this.connectedCallbacks, this.databaseRoot
     );
   }
 
@@ -49,7 +51,7 @@ class FakeReference {
     const path = this.path === '/' ? `/${childPath}` : `${this.path}/${childPath}`;
     return new FakeReference(
       path, this.database.app.name, this.databaseName,
-      this.valueListenerAdds, this.connectedCallbacks
+      this.valueListenerAdds, this.connectedCallbacks, this.databaseRoot
     );
   }
 
@@ -57,6 +59,7 @@ class FakeReference {
     return (
       this.database.app.name === other.database.app.name &&
       this.databaseName === other.databaseName &&
+      this.databaseRoot === other.databaseRoot &&
       this.path === other.path
     );
   }
@@ -84,7 +87,7 @@ class FakeReference {
   }
 
   toString() {
-    return `https://${this.databaseName}.test${this.path}`;
+    return this.databaseRoot + this.path;
   }
 
   transaction() {/* The constructor only checks that this method exists. */}
@@ -244,4 +247,25 @@ test('tracks disconnects and trims the cache per database instance', () => {
   second.cache();
   secondReference.emitConnected(false);
   assert.equal(second.uncache(), false);
+});
+
+test('does not trim a database whose identity extends another database identity', () => {
+  NodeFire.setCacheSize(10);
+  const firstReference = new FakeReference(
+    '/', 'prefix-app', 'first-database', new Map(), [],
+    'https://emulator.test/?ns=foo'
+  );
+  const secondReference = new FakeReference(
+    '/', 'prefix-app', 'second-database', new Map(), [],
+    'https://emulator.test/?ns=foobar'
+  );
+  const first = new NodeFire(firstReference).childRaw('value');
+  const second = new NodeFire(secondReference).childRaw('value');
+
+  first.cache();
+  second.cache();
+  firstReference.emitConnected(false);
+
+  assert.equal(first.uncache(), false);
+  assert.equal(second.uncache(), true);
 });

--- a/tests/cache.mjs
+++ b/tests/cache.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import {afterEach, test} from 'node:test';
+
+import NodeFireModule from '../built/index.js';
+
+const {default: NodeFire} = NodeFireModule;
+let appCounter = 0;
+
+class FakeReference {
+  constructor(path = '/', appName = `cache-test-${++appCounter}`) {
+    this.path = path;
+    this.database = {app: {name: appName}};
+  }
+
+  get key() {
+    return this.path === '/' ? null : this.path.slice(this.path.lastIndexOf('/') + 1);
+  }
+
+  get parent() {
+    if (this.path === '/') return null;
+    const path = this.path.slice(0, this.path.lastIndexOf('/')) || '/';
+    return new FakeReference(path, this.database.app.name);
+  }
+
+  get ref() {
+    return this;
+  }
+
+  get root() {
+    return new FakeReference('/', this.database.app.name);
+  }
+
+  child(childPath) {
+    const path = this.path === '/' ? `/${childPath}` : `${this.path}/${childPath}`;
+    return new FakeReference(path, this.database.app.name);
+  }
+
+  isEqual(other) {
+    return this.database.app.name === other.database.app.name && this.path === other.path;
+  }
+
+  off() {/* Nothing to detach in the fake reference. */}
+
+  on(event, callback) {
+    if (this.path === '/.info/serverTimeOffset') {
+      // eslint-disable-next-line lodash/prefer-constant
+      callback({val: () => 0});
+    }
+    if (this.path === '/.info/connected') {
+      // eslint-disable-next-line lodash/prefer-constant
+      callback({val: () => true});
+    }
+  }
+
+  toString() {
+    return `https://${this.database.app.name}.test${this.path}`;
+  }
+
+  transaction() {/* The constructor only checks that this method exists. */}
+}
+
+afterEach(() => {
+  NodeFire.setCacheSize(0);
+  NodeFire.resetCacheStats();
+});
+
+test('counts a cached ancestor as a cache hit', () => {
+  NodeFire.setCacheSize(10);
+  const root = new NodeFire(new FakeReference());
+
+  root.childRaw('parent').cache();
+  root.childRaw('parent/child/grandchild').cache();
+
+  assert.deepEqual(NodeFire.getCacheStats(), {
+    count: 1,
+    maxSize: 10,
+    hits: 1,
+    misses: 1,
+    hitRate: 0.5
+  });
+
+  NodeFire.resetCacheStats();
+  assert.deepEqual(NodeFire.getCacheStats(), {
+    count: 1,
+    maxSize: 10,
+    hits: 0,
+    misses: 0,
+    hitRate: 0
+  });
+});
+
+test('counts the cached root as a cache hit for descendants', () => {
+  NodeFire.setCacheSize(10);
+  const root = new NodeFire(new FakeReference());
+
+  assert.equal(root.path, '/');
+  root.cache();
+  root.childRaw('child/grandchild').cache();
+
+  assert.deepEqual(NodeFire.getCacheStats(), {
+    count: 1,
+    maxSize: 10,
+    hits: 1,
+    misses: 1,
+    hitRate: 0.5
+  });
+});
+
+test('counts unrelated paths as cache misses', () => {
+  NodeFire.setCacheSize(10);
+  const root = new NodeFire(new FakeReference());
+
+  root.childRaw('one').cache();
+  root.childRaw('two').cache();
+
+  assert.deepEqual(NodeFire.getCacheStats(), {
+    count: 2,
+    maxSize: 10,
+    hits: 0,
+    misses: 2,
+    hitRate: 0
+  });
+});

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,5 +1,5 @@
 import type {Reference} from 'firebase-admin/database';
-import NodeFire, {type ChildNodeFireOf} from '../src';
+import NodeFire, {type CacheStats, type ChildNodeFireOf} from '../src';
 
 type Equal<Left, Right> =
   (<T>() => T extends Left ? 1 : 2) extends
@@ -25,6 +25,13 @@ interface Database {
 
 declare const reference: Reference;
 const untyped = new NodeFire(reference);
+const unusedCacheStats: CacheStats = NodeFire.getCacheStats();
+const unusedCacheCount: number = unusedCacheStats.count;
+const unusedCacheMaxSize: number = unusedCacheStats.maxSize;
+const unusedCacheHits: number = unusedCacheStats.hits;
+const unusedCacheMisses: number = unusedCacheStats.misses;
+const unusedCacheHitRate: number = unusedCacheStats.hitRate;
+NodeFire.resetCacheStats();
 type UntypedParentResult = Expect<
   Equal<GetResult<NonNullable<typeof untyped.parent>>, unknown>
 >;


### PR DESCRIPTION
## Summary

- count a cache attempt as a hit when either the requested path or any ancestor is already pinned
- continue pinning the requested path on ancestor hits so `uncache()` retains its existing behavior
- namespace cache entries by both Admin app and database instance
- add `getCacheStats()` with `{count, maxSize, hits, misses, hitRate}` and add `resetCacheStats()`
- preserve the existing count, hit-rate, and reset methods as deprecated, receiver-independent wrappers
- document the API and add runtime plus type-level regression coverage

## Why

`cache()` previously checked only the exact requested path, so a descendant of an already cached reference was recorded as a miss even though the ancestor listener covered it. Callers could also read only the derived hit rate, not the underlying hit and miss counts needed for telemetry.

The ancestor lookup must still preserve per-path pinning semantics, distinguish multiple database instances attached to one Admin app, and keep the deprecated static methods safe to call without a receiver.

## Impact

Cache accounting now reflects ancestor coverage while preserving explicit pinning and `uncache()` behavior. Cache entries are isolated per app and database instance. Existing callers remain source-compatible, while new callers can consume a single typed stats snapshot and reset its counters through the clearer API.

## Validation

- `yarn test` (5 tests)
- `yarn lint`
- `yarn check-types`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/nodefire/55)
<!-- Reviewable:end -->