### PR TITLE
Expose transaction metadata on returned promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodefire",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "A promise-centric Firebase library for NodeJS",
   "main": "built/index.js",
   "types": "built/index.d.ts",

--- a/src/nodefire.ts
+++ b/src/nodefire.ts
@@ -49,6 +49,17 @@ export interface NodeFireError extends Error {
   timeout?: number;
 }
 
+export interface TransactionMetadata {
+  outcome?: 'commit' | 'error' | 'skip';
+  tries?: number;
+  prefetchDuration?: number;
+  duration?: number;
+}
+
+export interface TransactionPromise<T> extends Promise<T> {
+  transaction: TransactionMetadata;
+}
+
 declare module '@firebase/database-types' {
   interface Reference {
     // Added to Reference by firecrypt; use instead of the raw firebaseChildrenKeys call when
@@ -453,21 +464,16 @@ export default class NodeFire<
       prefetchValue?: boolean,
       timeout?: number
     }
-  ): Promise<ReadValue<Root> | null | undefined> {
+  ): TransactionPromise<ReadValue<Root> | null | undefined> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;  // easier than using => functions or binding explicitly
     options = options ?? {};
     let tries = 0, result: any;
     const startTime = self.now;
     let prefetchDoneTime: number;
-    const metadata: {
-      outcome?: any;
-      tries?: any;
-      prefetchDuration?:
-      number; duration?: number;
-    } = {};
+    const metadata: TransactionMetadata = {};
 
-    function fillMetadata(outcome: any) {
+    function fillMetadata(outcome: NonNullable<TransactionMetadata['outcome']>) {
       if (metadata.outcome) return;
       metadata.outcome = outcome;
       metadata.tries = tries;
@@ -481,13 +487,13 @@ export default class NodeFire<
 
     const op = {ref: this, method: 'transaction', args: [updateFunction]};
 
-    return Promise.all(
+    const promise = Promise.all(
       _.map(
         operationInterceptors,
         (interceptor: InterceptOperationsCallback) => Promise.resolve(interceptor(op, options))
       )
     ).then(() => {
-      const promise = new Promise<ReadValue<Root> | null | undefined>((resolve, reject) => {
+      return new Promise<ReadValue<Root> | null | undefined>((resolve, reject) => {
         const wrappedRejectNoResult = wrapReject(self, 'transaction', reject);
         let wrappedReject = wrappedRejectNoResult;
         let aborted = false, settled = false;
@@ -579,8 +585,8 @@ export default class NodeFire<
           txn();
         }
       });
-      return _.assign(promise, {transaction: metadata});
     });
+    return _.assign(promise, {transaction: metadata});
   }
 
   /**

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -34,6 +34,13 @@ const unusedUntypedAsTyped: NodeFire<Database> = untyped;
 
 const user = db.child('organizations/:organization/users/:user');
 type UserResult = Expect<Equal<GetResult<typeof user>, User | null>>;
+const unusedTransaction = user.transaction(value => value);
+type TransactionResult = Expect<Equal<
+  Awaited<typeof unusedTransaction>,
+  User | null | undefined
+>>;
+const unusedTransactionOutcome: 'commit' | 'error' | 'skip' | undefined =
+  unusedTransaction.transaction.outcome;
 type InferredUser = Expect<Equal<
   typeof user extends NodeFire<
     infer Current, infer unusedRules, infer unusedWrite
@@ -136,6 +143,7 @@ type RuntimeOrganizationParentResult = Expect<
 export type NavigationTypeTests = [
   UntypedParentResult,
   UserResult,
+  TransactionResult,
   InferredUser,
   UsersResult,
   OrganizationResult,


### PR DESCRIPTION
## Summary

- attach transaction metadata to the promise actually returned to callers
- expose typed `TransactionMetadata` and `TransactionPromise` contracts with compile-time coverage
- bump the package version to 7.0.1

## Root cause

`transaction()` created its Firebase transaction promise inside the operation-interceptor continuation and attached metadata to that inner promise. The method returned the outer `Promise.all(...).then(...)` promise instead, so callers could not access `.transaction`.

## Impact

Callers can now inspect the returned promise's transaction outcome, attempt count, and duration metadata as intended.

## Validation

- `yarn check-types`
- `yarn lint`
- `yarn build`
- focused runtime transaction check confirming the returned promise exposes and populates metadata
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/nodefire/56)
<!-- Reviewable:end -->
